### PR TITLE
Bugfix: Remove unused custom translation

### DIFF
--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -38,7 +38,6 @@ nl:
         change_ballot: "Wijzig u stem"
         no_ballots_allowed: "De selectieronde is voorbij"
         different_heading_assigned: "U heeft al gestemd in een andere groep: %{heading_link}"
-        not_logged_in: "U moet %{signin} of %{signup} om verder te gaan."
         casted_offline: "U heeft al offline deelgenomen"
         not_enough_available_votes: "U heeft uw maximaal aantal stemmen bereikt."
     groups:


### PR DESCRIPTION
## References

We were getting the following error:

```
INFO -- : [f7e0c9dd-b42a-4ed0-b8e6-1afe5a174d8a] Completed 500 Internal Server Error in 100ms (ActiveRecord: 18.1ms | Allocations: 38581)
FATAL -- : [f7e0c9dd-b42a-4ed0-b8e6-1afe5a174d8a]   
ActionView::Template::Error (missing interpolation argument :signin in "Jo moatte %{signin} of %{signup} om fierder te gean." ({:verify_account=>"<a href=\"/verification\">je account verifieren</a>", :my_heading=>"<a href=\"/budgets/2/investments?heading_id=2\">Jong erfgoed van Fryslân (1965-2000)</a>", :change_ballot=>"<a href=\"/budgets/2/ballot\">Wizigje jo stim</a>", :heading_link=>nil} given)):
    1: <%= render Budgets::Investments::BallotComponent.new(
    2:   investment: investment,
    3:   investment_ids: investment_ids,
    4:   ballot: ballot
   
config/initializers/i18n_translation.rb:20:in `t'
app/components/application_component.rb:3:in `t'
app/components/budgets/investments/ballot_component.rb:50:in `cannot_vote_text'
app/components/budgets/investments/ballot_component.html.erb:46:in `call'
```


## Objectives

Remove unused custom translation to avoid raising the error